### PR TITLE
Use Capture::Tiny instead of IO::CaptureOutput

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,9 +1,9 @@
 requires "perl" => "5.006";
 
 on 'test' => sub {
+  requires "Capture::Tiny" => "0";
   requires "ExtUtils::MakeMaker" => "0";
   requires "File::Spec::Functions" => "0";
-  requires "IO::CaptureOutput" => "1.08";
   requires "List::Util" => "0";
   requires "Test::More" => "0";
   requires "strict" => "0";

--- a/t/autoflush.t
+++ b/t/autoflush.t
@@ -8,13 +8,16 @@ use strict;
 use warnings;
 
 use Test::More;
-use IO::CaptureOutput 1.08 qw/qxx/;
+use Capture::Tiny 'capture';
 
 plan tests => 1;
 
 $ENV{PERL5OPT} = '-MDevel::Autoflush';
 
-my ( $stdout, $stderr ) = qxx( $^X, '-we', 'print $| ? 1 : 0,  "\n"' );
+my ( $stdout, $stderr ) = capture {
+    system( $^X, '-we', 'print $| ? 1 : 0,  "\n"' );
+};
+
 chomp($stdout);
 is( $stdout, 1, "autoflush was set" ) or diag "STDERR: $stderr";
 


### PR DESCRIPTION
As the latter is deprecated as of version 1.1105 (2019-10-25).  This should enable us to remove one dependency for CPAN::Reporter and, in turn, Task::CPAN::Reporter.